### PR TITLE
Fixed App-Service init dead-lock

### DIFF
--- a/src/AI4E.AspNetCore/WebHostExtension.cs
+++ b/src/AI4E.AspNetCore/WebHostExtension.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
@@ -19,6 +19,10 @@ namespace AI4E.AspNetCore
             if (applicationServiceManager != null)
             {
                 await applicationServiceManager.InitializeApplicationServicesAsync(serviceProvider, cancellation);
+
+                // Forces an asynchronous yield to the continuation that blocks synchronously
+                // We do not want the contiuations of applicationServiceManager.InitializeApplicationServicesAsync to be blocked indefinitely
+                await Task.Yield();
             }
 
             return webhost;

--- a/src/AI4E.Modularity.Host/ServiceCollectionExtension.cs
+++ b/src/AI4E.Modularity.Host/ServiceCollectionExtension.cs
@@ -77,7 +77,6 @@ namespace AI4E.Modularity.Host
 
         private static void ConfigureApplicationServices(ApplicationServiceManager serviceManager)
         {
-            serviceManager.AddService<IMessageDispatcher>();
             serviceManager.AddService<DebugPort>(isRequiredService: false);
         }
 
@@ -93,8 +92,6 @@ namespace AI4E.Modularity.Host
 
             var optionsAccessor = serviceProvider.GetRequiredService<IOptions<ModularityOptions>>();
             var options = optionsAccessor.Value ?? new ModularityOptions();
-
-
 
             if (options.EnableDebugging)
             {

--- a/src/AI4E.Modularity.Module/ServiceCollectionExtensions.cs
+++ b/src/AI4E.Modularity.Module/ServiceCollectionExtensions.cs
@@ -50,7 +50,6 @@ namespace AI4E.Modularity.Module
 
         private static void ConfigureApplicationServices(ApplicationServiceManager serviceManager)
         {
-            serviceManager.AddService<IMessageDispatcher>();
             serviceManager.AddService<DebugConnection>();
         }
 

--- a/src/AI4E.Modularity/Debug/DebugPort.cs
+++ b/src/AI4E.Modularity/Debug/DebugPort.cs
@@ -105,8 +105,10 @@ namespace AI4E.Modularity.Debug
             // - the handler for the debug messages is registered AND
             // - reached a globally consistent state (its routes are registered).
 
-            // TODO: https://github.com/AI4E/AI4E/issues/111
-            //await ((_messageDispatcher as IAsyncInitialization)?.Initialization?.WithCancellation(cancellation) ?? Task.CompletedTask);
+            if (_messageDispatcher is IAsyncInitialization asyncInitialization)
+            {
+                await asyncInitialization.Initialization.WithCancellation(cancellation);
+            }
 
             _tcpHost.Start();
             var localAddress = (IPEndPoint)_tcpHost.Server.LocalEndPoint;

--- a/src/SignalR/AI4E.Routing.SignalR.Client/ServiceCollectionExtension.cs
+++ b/src/SignalR/AI4E.Routing.SignalR.Client/ServiceCollectionExtension.cs
@@ -81,8 +81,6 @@ namespace AI4E.Routing.SignalR.Client
             serviceCollection.ConfigureHubConnectionBuilder(configureHubConnection);
             // Do NOT Add the HubConnection to the service container.
             // The connection builder already does this and it would lead to infinite recursion.
-
-            serviceCollection.ConfigureApplicationServices(serviceManager => serviceManager.AddService<IMessageDispatcher>());
         }
     }
 }


### PR DESCRIPTION
This fixes a dead-lock in the service initialization. The app-service init route is called in the modules main method, followed bay a blocking call. This blocked any continuation of the service init functions to be invoked.
This should also fix #111. This partially fixes #39, but there is an external requirement before this can be fixed completely.